### PR TITLE
Fix lines appearing between grid squares in Safari

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactEventHandler, useCallback, useEffect, useRef } from 'react';
+import { forwardRef, type ReactEventHandler, useCallback } from 'react';
 import { type Board, getBoardColor, getBoardHeight, getBoardWidth } from '../board';
 import type { Color } from '../color';
 import { CirclePath } from './CirclePath';
@@ -12,10 +12,8 @@ export interface GridProps {
 const SIZE = 35;
 const OVERLAP = 0;
 
-export const Grid: FC<GridProps> = ({ board, onClick }) => {
-  const parentRef = useRef<HTMLDivElement>(null);
-  const svgRef = useRef<SVGSVGElement>(null);
-
+export const Grid = forwardRef<SVGSVGElement, GridProps>((props, ref) => {
+  const { board, onClick } = props;
   const size = SIZE;
   const width = getBoardWidth(board);
   const height = getBoardHeight(board);
@@ -29,70 +27,44 @@ export const Grid: FC<GridProps> = ({ board, onClick }) => {
     onClick(getBoardColor(board, x, y)!);
   }, [board, onClick]);
 
-  useEffect(() => {
-    const parent = parentRef.current;
-    const svg = svgRef.current;
-    if (!parent || !svg) return;
-    const callback = (entries: ResizeObserverEntry[]) => {
-      const originalWidth = entries[0].contentRect.width;
-      const flooredWidth = Math.floor(originalWidth / width) * width;
-      svg.style.width = flooredWidth / originalWidth * 100 + '%';
-    };
-    const observer = new ResizeObserver(callback);
-    observer.observe(parent);
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
   return (
-    <div
-      ref={parentRef}
+    <svg
+      ref={ref}
+      className="Grid"
+      viewBox={VIEWBOX}
+      preserveAspectRatio="none"
       style={{
-        width: '100%',
-        height: '100%',
-        display: 'grid',
-        placeItems: 'center',
+        borderRadius: '4px',
+        boxShadow: 'var(--box-shadow)',
       }}
     >
-      <svg
-        ref={svgRef}
-        className="Grid"
-        viewBox={VIEWBOX}
-        preserveAspectRatio="none"
-        style={{
-          borderRadius: '4px',
-          boxShadow: 'var(--box-shadow)',
-        }}
-      >
-        {Array.from({ length: height }, (_, y) => [
-          Array.from({ length: width }, (_, x) => (
-            <GridSquare
-              key={x + ',' + y}
-              x={x * size - OVERLAP}
-              y={y * size - OVERLAP}
-              width={size + OVERLAP * 2}
-              height={size + OVERLAP * 2}
-              onPointerDown={handleClick}
-              data-x={x}
-              data-y={y}
-              distance={Math.sqrt(x ** 2 + y ** 2)}
-              color={getBoardColor(board, x, y)!}
-            />
-          ))
-        ])}
+      {Array.from({ length: height }, (_, y) => [
+        Array.from({ length: width }, (_, x) => (
+          <GridSquare
+            key={x + ',' + y}
+            x={x * size - OVERLAP}
+            y={y * size - OVERLAP}
+            width={size + OVERLAP * 2}
+            height={size + OVERLAP * 2}
+            onPointerDown={handleClick}
+            data-x={x}
+            data-y={y}
+            distance={Math.sqrt(x ** 2 + y ** 2)}
+            color={getBoardColor(board, x, y)!}
+          />
+        ))
+      ])}
 
-        <CirclePath
-          outerRadius={size * 0.3}
-          innerRadius={size * 0.2}
-          cx={size / 2}
-          cy={size / 2}
-          fill="#fff"
-          style={{
-            pointerEvents: 'none',
-          }}
-        />
-      </svg>
-    </div>
+      <CirclePath
+        outerRadius={size * 0.3}
+        innerRadius={size * 0.2}
+        cx={size / 2}
+        cy={size / 2}
+        fill="#fff"
+        style={{
+          pointerEvents: 'none',
+        }}
+      />
+    </svg>
   );
-};
+});

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactEventHandler, useCallback } from 'react';
+import { type FC, type ReactEventHandler, useCallback, useEffect, useRef } from 'react';
 import { type Board, getBoardColor, getBoardHeight, getBoardWidth } from '../board';
 import type { Color } from '../color';
 import { CirclePath } from './CirclePath';
@@ -10,8 +10,12 @@ export interface GridProps {
 }
 
 const SIZE = 35;
+const OVERLAP = 0;
 
 export const Grid: FC<GridProps> = ({ board, onClick }) => {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
   const size = SIZE;
   const width = getBoardWidth(board);
   const height = getBoardHeight(board);
@@ -25,43 +29,70 @@ export const Grid: FC<GridProps> = ({ board, onClick }) => {
     onClick(getBoardColor(board, x, y)!);
   }, [board, onClick]);
 
+  useEffect(() => {
+    const parent = parentRef.current;
+    const svg = svgRef.current;
+    if (!parent || !svg) return;
+    const callback = (entries: ResizeObserverEntry[]) => {
+      const originalWidth = entries[0].contentRect.width;
+      const flooredWidth = Math.floor(originalWidth / width) * width;
+      svg.style.width = flooredWidth / originalWidth * 100 + '%';
+    };
+    const observer = new ResizeObserver(callback);
+    observer.observe(parent);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
-    <svg
-      className="Grid"
-      viewBox={VIEWBOX}
-      preserveAspectRatio="none"
+    <div
+      ref={parentRef}
       style={{
-        borderRadius: '4px',
-        boxShadow: 'var(--box-shadow)',
+        width: '100%',
+        height: '100%',
+        display: 'grid',
+        placeItems: 'center',
       }}
     >
-      {Array.from({ length: height }, (_, y) => [
-        Array.from({ length: width }, (_, x) => (
-          <GridSquare
-            key={x + ',' + y}
-            x={x * size - 0.5}
-            y={y * size - 0.5}
-            width={size + 1}
-            height={size + 1}
-            onPointerDown={handleClick}
-            data-x={x}
-            data-y={y}
-            distance={Math.sqrt(x ** 2 + y ** 2)}
-            color={getBoardColor(board, x, y)!}
-          />
-        ))
-      ])}
-
-      <CirclePath
-        outerRadius={size * 0.3}
-        innerRadius={size * 0.2}
-        cx={size / 2}
-        cy={size / 2}
-        fill="#fff"
+      <svg
+        ref={svgRef}
+        className="Grid"
+        viewBox={VIEWBOX}
+        preserveAspectRatio="none"
         style={{
-          pointerEvents: 'none',
+          borderRadius: '4px',
+          boxShadow: 'var(--box-shadow)',
         }}
-      />
-    </svg>
+      >
+        {Array.from({ length: height }, (_, y) => [
+          Array.from({ length: width }, (_, x) => (
+            <GridSquare
+              key={x + ',' + y}
+              x={x * size - OVERLAP}
+              y={y * size - OVERLAP}
+              width={size + OVERLAP * 2}
+              height={size + OVERLAP * 2}
+              onPointerDown={handleClick}
+              data-x={x}
+              data-y={y}
+              distance={Math.sqrt(x ** 2 + y ** 2)}
+              color={getBoardColor(board, x, y)!}
+            />
+          ))
+        ])}
+
+        <CirclePath
+          outerRadius={size * 0.3}
+          innerRadius={size * 0.2}
+          cx={size / 2}
+          cy={size / 2}
+          fill="#fff"
+          style={{
+            pointerEvents: 'none',
+          }}
+        />
+      </svg>
+    </div>
   );
 };

--- a/src/components/GridConnected.tsx
+++ b/src/components/GridConnected.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useGameState } from '../use-game-state';
-import { Grid } from './Grid';
+import { GridSize } from './GridSize';
 
 export const GridConnected: FC = () => {
   const { board, flood } = useGameState();
@@ -8,6 +8,6 @@ export const GridConnected: FC = () => {
   if (!board) return null;
 
   return (
-    <Grid board={board} onClick={flood} />
+    <GridSize board={board} onClick={flood} />
   );
 };

--- a/src/components/GridSize.tsx
+++ b/src/components/GridSize.tsx
@@ -1,0 +1,45 @@
+import { type FC, useEffect, useRef } from 'react';
+import { getBoardWidth } from '../board';
+import { Grid, GridProps } from './Grid';
+
+export const GridSize: FC<GridProps> = (props) => {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const childRef = useRef<SVGSVGElement>(null);
+  const width = getBoardWidth(props.board);
+
+  useEffect(() => {
+    const parent = parentRef.current;
+    const child = childRef.current;
+    if (!parent || !child) return;
+
+    const callback = (entries: ResizeObserverEntry[]) => {
+      const originalWidth = entries[0].contentRect.width;
+      const flooredWidth = Math.floor(originalWidth / width) * width;
+      child.style.width = flooredWidth / originalWidth * 100 + '%';
+    };
+
+    const observer = new ResizeObserver(callback);
+    observer.observe(parent);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={parentRef}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'grid',
+        placeItems: 'center',
+      }}
+    >
+      <Grid
+        ref={childRef}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/src/components/GridSize.tsx
+++ b/src/components/GridSize.tsx
@@ -14,6 +14,8 @@ export const GridSize: FC<GridProps> = (props) => {
     const originalWidth = entries[0].contentRect.width;
     const flooredWidth = Math.floor(originalWidth / width) * width;
 
+    // Use percentage over fixed pixel size to allow further resize observer
+    // callbacks to be triggered. Otherwise the grid will always be one size.
     child.style.width = flooredWidth / originalWidth * 100 + '%';
   }, []);
 


### PR DESCRIPTION
If the grid is 14x14 squares we want to resize the grid to be a multiple of 14px wide/tall such that the total width/height is a whole number of pixels. This prevents Safari from poorly handling subpixel rendering.